### PR TITLE
DnsRecordBase: Update Test() to better handle missing record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix property descriptions in schema throughout.
   - Fix uploading of code coverage that was broken since Sampler had a bug.
   - Fix examples so the license information point to the correct default branch.
+- DnsRecordBase
+  - Fixed so that `Compare-DscParameterState` is used in the method `Test()`
+    if the record already exist, to compare the properties except `Ensure`
+    in the desired state against the actual state ([issue #205](https://github.com/dsccommunity/xDnsServer/issues/205)).
 - xDnsServerDiagnostics
   - Fix EnableLogFileRollover Parameter name in README.
 - xDnsRecord

--- a/source/Classes/001.DnsRecordBase.ps1
+++ b/source/Classes/001.DnsRecordBase.ps1
@@ -208,19 +208,28 @@ class DnsRecordBase
 
         if ($this.Ensure -eq 'Present')
         {
-            # Remove properties that have $null as the value
-            @($desiredState.Keys) | ForEach-Object -Process {
-                if ($null -eq $desiredState[$_])
+            if ($currentState.Ensure -eq 'Present')
+            {
+                # Remove properties that have $null as the value
+                @($desiredState.Keys) | ForEach-Object -Process {
+                    if ($null -eq $desiredState[$_])
+                    {
+                        $desiredState.Remove($_)
+                    }
+                }
+
+                # Returns all enforced properties not in desires state, or $null if all enforced properties are in desired state
+                $propertiesNotInDesiredState = Compare-DscParameterState -CurrentValues $currentState -DesiredValues $desiredState -Properties $desiredState.Keys -ExcludeProperties @('Ensure')
+
+                if ($propertiesNotInDesiredState)
                 {
-                    $desiredState.Remove($_)
+                    $isInDesiredState = $false
                 }
             }
-
-            # Returns all enforced properties not in desires state, or $null if all enforced properties are in desired state
-            $propertiesNotInDesiredState = Compare-DscParameterState -CurrentValues $currentState -DesiredValues $desiredState -Properties $desiredState.Keys
-
-            if ($propertiesNotInDesiredState)
+            else
             {
+                Write-Verbose -Message ($this.localizedData.PropertyIsNotInDesiredState -f 'Ensure', $desiredState['Ensure'], $currentState['Ensure'])
+
                 $isInDesiredState = $false
             }
         }


### PR DESCRIPTION

#### Pull Request (PR) description
- DnsRecordBase
  - Fixed so that `Compare-DscParameterState` is used in the method `Test()`
    if the record already exist, to compare the properties except `Ensure`
    in the desired state against the actual state (issue #205).

I could not find a way to better test this change than the unit test already did. Let me know if that can be improved.

#### This Pull Request (PR) fixes the following issues

- Fixes #205

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xdnsserver/208)
<!-- Reviewable:end -->
