### PR TITLE
BREAKING CHANGE: DnsServerSetting: Remove properties `EnableEDnsProbes` and `EDnsCacheTimeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - BREAKING CHANGE: The properties `Forwarders` and `ForwardingTimeout` has
     been removed ([issue #192](https://github.com/dsccommunity/DnsServerDsc/issues/192)).
     Use the resource _DnsServerForwarder_ to enforce these properties.
+  - BREAKING CHANGE: The properties `EnableEDnsProbes` and `EDnsCacheTimeout` has
+    been removed ([issue #195](https://github.com/dsccommunity/DnsServerDsc/issues/195)).
+    Use the resource _DnsServerEDns_ to enforce these properties.
 
 ### Added
 

--- a/source/DSCResources/DSC_DnsServerSetting/DSC_DnsServerSetting.psm1
+++ b/source/DSCResources/DSC_DnsServerSetting/DSC_DnsServerSetting.psm1
@@ -6,7 +6,7 @@ Import-Module -Name $script:dnsServerDscCommonPath
 
 $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
-$properties = 'LocalNetPriority', 'AutoConfigFileZones', 'MaxCacheTTL', 'AddressAnswerLimit', 'UpdateOptions', 'DisableAutoReverseZones', 'StrictFileParsing', 'NoRecursion', 'DisjointNets', 'EnableDirectoryPartitions', 'XfrConnectTimeout', 'AllowUpdate', 'DsAvailable', 'BootMethod', 'LooseWildcarding', 'DsPollingInterval', 'BindSecondaries', 'LogLevel', 'AutoCacheUpdate', 'EnableDnsSec', 'EnableEDnsProbes', 'NameCheckFlag', 'EDnsCacheTimeout', 'SendPort', 'WriteAuthorityNS', 'IsSlave', 'RecursionTimeout', 'ListenAddresses', 'DsTombstoneInterval', 'RecursionRetry', 'RpcProtocol', 'SecureResponses', 'RoundRobin', 'ForwardDelegations', 'MaxNegativeCacheTTL'
+$properties = 'LocalNetPriority', 'AutoConfigFileZones', 'MaxCacheTTL', 'AddressAnswerLimit', 'UpdateOptions', 'DisableAutoReverseZones', 'StrictFileParsing', 'NoRecursion', 'DisjointNets', 'EnableDirectoryPartitions', 'XfrConnectTimeout', 'AllowUpdate', 'DsAvailable', 'BootMethod', 'LooseWildcarding', 'DsPollingInterval', 'BindSecondaries', 'LogLevel', 'AutoCacheUpdate', 'EnableDnsSec', 'NameCheckFlag', 'SendPort', 'WriteAuthorityNS', 'IsSlave', 'RecursionTimeout', 'ListenAddresses', 'DsTombstoneInterval', 'RecursionRetry', 'RpcProtocol', 'SecureResponses', 'RoundRobin', 'ForwardDelegations', 'MaxNegativeCacheTTL'
 
 <#
     .SYNOPSIS
@@ -90,10 +90,6 @@ function Get-TargetResource
         Lifetime of tombstoned records in Directory Service integrated zones,
         expressed in seconds.
 
-    .PARAMETER EDnsCacheTimeout
-        Lifetime, in seconds, of the cached information describing the EDNS version
-        supported by other DNS Servers.
-
     .PARAMETER EnableDirectoryPartitions
         Specifies whether support for application directory partitions is enabled on
         the DNS Server.
@@ -101,13 +97,6 @@ function Get-TargetResource
     .PARAMETER EnableDnsSec
         Specifies whether the DNS Server includes DNSSEC-specific RRs, KEY, SIG, and
         NXT in a response.
-
-    .PARAMETER EnableEDnsProbes
-        Specifies the behavior of the DNS Server. When TRUE, the DNS Server always
-        responds with OPT resource records according to RFC 2671, unless the remote
-        server has indicated it does not support EDNS in a prior exchange. If FALSE,
-        the DNS Server responds to queries with OPTs only if OPTs are sent in the
-        original query.
 
     .PARAMETER ForwardDelegations
         Specifies whether queries to delegated sub-zones are forwarded.
@@ -229,20 +218,12 @@ function Set-TargetResource
         $DsTombstoneInterval,
 
         [Parameter()]
-        [uint32]
-        $EDnsCacheTimeout,
-
-        [Parameter()]
         [bool]
         $EnableDirectoryPartitions,
 
         [Parameter()]
         [uint32]
         $EnableDnsSec,
-
-        [Parameter()]
-        [bool]
-        $EnableEDnsProbes,
 
         [Parameter()]
         [uint32]
@@ -404,10 +385,6 @@ function Set-TargetResource
         Lifetime of tombstoned records in Directory Service integrated zones,
         expressed in seconds.
 
-    .PARAMETER EDnsCacheTimeout
-        Lifetime, in seconds, of the cached information describing the EDNS version
-        supported by other DNS Servers.
-
     .PARAMETER EnableDirectoryPartitions
         Specifies whether support for application directory partitions is enabled on
         the DNS Server.
@@ -415,13 +392,6 @@ function Set-TargetResource
     .PARAMETER EnableDnsSec
         Specifies whether the DNS Server includes DNSSEC-specific RRs, KEY, SIG, and
         NXT in a response.
-
-    .PARAMETER EnableEDnsProbes
-        Specifies the behavior of the DNS Server. When TRUE, the DNS Server always
-        responds with OPT resource records according to RFC 2671, unless the remote
-        server has indicated it does not support EDNS in a prior exchange. If FALSE,
-        the DNS Server responds to queries with OPTs only if OPTs are sent in the
-        original query.
 
     .PARAMETER ForwardDelegations
         Specifies whether queries to delegated sub-zones are forwarded.
@@ -544,20 +514,12 @@ function Test-TargetResource
         $DsTombstoneInterval,
 
         [Parameter()]
-        [uint32]
-        $EDnsCacheTimeout,
-
-        [Parameter()]
         [bool]
         $EnableDirectoryPartitions,
 
         [Parameter()]
         [uint32]
         $EnableDnsSec,
-
-        [Parameter()]
-        [bool]
-        $EnableEDnsProbes,
 
         [Parameter()]
         [uint32]

--- a/source/DSCResources/DSC_DnsServerSetting/DSC_DnsServerSetting.schema.mof
+++ b/source/DSCResources/DSC_DnsServerSetting/DSC_DnsServerSetting.schema.mof
@@ -12,10 +12,8 @@ class DSC_DnsServerSetting : OMI_BaseResource
     [Write, Description("Indicates whether the default port binding for a socket used to send queries to remote DNS Servers can be overridden.")] Boolean DisjointNets;
     [Write, Description("Interval, in seconds, to poll the DS-integrated zones.")] Uint32 DsPollingInterval;
     [Write, Description("Lifetime of tombstoned records in Directory Service integrated zones, expressed in seconds.")] Uint32 DsTombstoneInterval;
-    [Write, Description("Lifetime, in seconds, of the cached information describing the EDNS version supported by other DNS Servers.")] Uint32 EDnsCacheTimeout;
     [Write, Description("Specifies whether support for application directory partitions is enabled on the DNS Server.")] Boolean EnableDirectoryPartitions;
     [Write, Description("Specifies whether the DNS Server includes DNSSEC-specific RRs, KEY, SIG, and NXT in a response.")] Uint32 EnableDnsSec;
-    [Write, Description("Specifies the behavior of the DNS Server. When TRUE, the DNS Server always responds with OPT resource records according to RFC 2671, unless the remote server has indicated it does not support EDNS in a prior exchange. If FALSE, the DNS Server responds to queries with OPTs only if OPTs are sent in the original query.")] Boolean EnableEDnsProbes;
     [Write, Description("Specifies whether queries to delegated sub-zones are forwarded.")] Uint32 ForwardDelegations;
     [Write, Description("TRUE if the DNS server does not use recursion when name-resolution through forwarders fails.")] Boolean IsSlave;
     [Write, Description("Enumerates the list of IP addresses on which the DNS Server can receive queries.")] String ListenAddresses[];

--- a/tests/Integration/DSC_DnsServerSetting.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerSetting.Integration.Tests.ps1
@@ -76,10 +76,8 @@ try
                 $resourceCurrentState.DisjointNets               | Should -Be $ConfigurationData.AllNodes.DisjointNets
                 $resourceCurrentState.DsPollingInterval          | Should -Be $ConfigurationData.AllNodes.DsPollingInterval
                 $resourceCurrentState.DsTombstoneInterval        | Should -Be $ConfigurationData.AllNodes.DsTombstoneInterval
-                $resourceCurrentState.EDnsCacheTimeout           | Should -Be $ConfigurationData.AllNodes.EDnsCacheTimeout
                 $resourceCurrentState.EnableDirectoryPartitions  | Should -Be $ConfigurationData.AllNodes.EnableDirectoryPartitions
                 $resourceCurrentState.EnableDnsSec               | Should -Be $ConfigurationData.AllNodes.EnableDnsSec
-                $resourceCurrentState.EnableEDnsProbes           | Should -Be $ConfigurationData.AllNodes.EnableEDnsProbes
                 $resourceCurrentState.ForwardDelegations         | Should -Be $ConfigurationData.AllNodes.ForwardDelegations
                 $resourceCurrentState.IsSlave                    | Should -Be $ConfigurationData.AllNodes.IsSlave
                 $resourceCurrentState.ListenAddresses            | Should -Be $ConfigurationData.AllNodes.ListenAddresses

--- a/tests/Integration/DSC_DnsServerSetting.config.ps1
+++ b/tests/Integration/DSC_DnsServerSetting.config.ps1
@@ -24,10 +24,8 @@ $ConfigurationData = @{
             DisjointNets              = $false
             DsPollingInterval         = 180
             DsTombstoneInterval       = 1209600
-            EDnsCacheTimeout          = 900
             EnableDirectoryPartitions = $true
             EnableDnsSec              = 1
-            EnableEDnsProbes          = $true
             ForwardDelegations        = 0
             IsSlave                   = $false
             <#
@@ -77,10 +75,8 @@ Configuration DSC_DnsServerSetting_SetSettings_config
             DisjointNets              = $Node.DisjointNets
             DsPollingInterval         = $Node.DsPollingInterval
             DsTombstoneInterval       = $Node.DsTombstoneInterval
-            EDnsCacheTimeout          = $Node.EDnsCacheTimeout
             EnableDirectoryPartitions = $Node.EnableDirectoryPartitions
             EnableDnsSec              = $Node.EnableDnsSec
-            EnableEDnsProbes          = $Node.EnableEDnsProbes
             ForwardDelegations        = $Node.ForwardDelegations
             IsSlave                   = $Node.IsSlave
             ListenAddresses           = $Node.ListenAddresses

--- a/tests/Unit/DSC_DnsServerSetting.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerSetting.Tests.ps1
@@ -44,10 +44,8 @@ try
             DisjointNets              = $true
             DsPollingInterval         = 10
             DsTombstoneInterval       = 10
-            EDnsCacheTimeout          = 100
             EnableDirectoryPartitions = $false
             EnableDnsSec              = 0
-            EnableEDnsProbes          = $false
             ForwardDelegations        = 1
             IsSlave                   = $true
             ListenAddresses           = '192.168.0.10', '192.168.0.11'
@@ -92,10 +90,8 @@ try
             DsAvailable               = $true
             DsPollingInterval         = 180
             DsTombstoneInterval       = 1209600
-            EDnsCacheTimeout          = 900
             EnableDirectoryPartitions = $true
             EnableDnsSec              = 1
-            EnableEDnsProbes          = $true
             ForwardDelegations        = 0
             IsSlave                   = $false
             ListenAddresses           = $null


### PR DESCRIPTION
### Pull Request (PR) description
- DnsServerSetting
  - BREAKING CHANGE: The properties `EnableEDnsProbes` and `EDnsCacheTimeout` has
    been removed (issue #195). Use the resource _DnsServerEDns_ to enforce these properties.

### This Pull Request (PR) fixes the following issues

- Fixes #195

### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dnsserverdsc/243)
<!-- Reviewable:end -->
