### PR TITLE
DnsServerDsc: Align some class-based resources with new pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     base class. If a localization string key exist in a parent class's
     localization string file it will override the localization string key
     in any base class.
+- ResourceBase
+  - Added new method `Assert()` tha calls `Assert-Module` and `AssertProperties()`.
 
 ### Changed
 
@@ -60,6 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `AssertProperties()`, `Modify()`, and `GetCurrentState()` where the
     two latter ones must be overridden by a resource if calling the base
     methods `Set()` and `Get()`.
+  - Moved the `Assert-Module` from the constructor to a new method `Assert()`
+    that is called from `Get()`, `Test()`, and `Set()`. The method `Assert()`
+    also calls the method `AssertProperties()`. The method `Assert()` is not
+    meant to be overridden, but can if there is a reason not to run
+    `Assert-Module` and or `AssertProperties()`.
 - Integration tests
   - Added commands in the DnsRecord* integration tests to wait for the LCM
     before moving to the next test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     To enforce theses properties, use resource _DnsServerEDns_ using the
     properties `EnablePollutionProtection`, `MaxTtl`, and `MaxNegativeTtl`
     respectively.
+- ResourceBase
+  - For the method `Get()` the overload that took a `[Microsoft.Management.Infrastructure.CimInstance]`
+    was removed as it is not the correct pattern going forward.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests
   - Added commands in the DnsRecord* integration tests to wait for the LCM
     before moving to the next test.
+- DnsServerCache
+  - Moved to the same coding pattern as _DnsServerRecursion_.
+- DnsServerEDns
+  - Moved to the same coding pattern as _DnsServerRecursion_.
+- DnsServerScavenging
+  - Moved to the same coding pattern as _DnsServerRecursion_.
 
 ## [2.0.0] - 2021-03-26
 

--- a/source/Classes/001.ResourceBase.ps1
+++ b/source/Classes/001.ResourceBase.ps1
@@ -17,13 +17,13 @@ class ResourceBase
     # Default constructor
     ResourceBase()
     {
-        Assert-Module -ModuleName 'DnsServer'
-
         $this.localizedData = Get-LocalizedDataRecursive -ClassName ($this | Get-ClassName -Recurse)
     }
 
     [ResourceBase] Get()
     {
+        $this.Assert()
+
         Write-Verbose -Message ($this.localizedData.GetCurrentState -f $this.DnsServer, $this.GetType().Name)
 
         # Get all key properties.
@@ -81,7 +81,7 @@ class ResourceBase
 
     [void] Set()
     {
-        $this.AssertProperties()
+        $this.Assert()
 
         Write-Verbose -Message ($this.localizedData.SetDesiredState -f $this.DnsServer, $this.GetType().Name)
 
@@ -117,7 +117,7 @@ class ResourceBase
     {
         Write-Verbose -Message ($this.localizedData.TestDesiredState -f $this.DnsServer, $this.GetType().Name)
 
-        $this.AssertProperties()
+        $this.Assert()
 
         $isInDesiredState = $true
 
@@ -191,6 +191,14 @@ class ResourceBase
         }
 
         return $desiredState
+    }
+
+    # This method should normally not be overridden.
+    hidden [void] Assert()
+    {
+        Assert-Module -ModuleName 'DnsServer'
+
+        $this.AssertProperties()
     }
 
     # This method can be overridden if resource specific asserts are needed.

--- a/source/Classes/001.ResourceBase.ps1
+++ b/source/Classes/001.ResourceBase.ps1
@@ -53,29 +53,20 @@ class ResourceBase
 
         $getCurrentStateResult = $this.GetCurrentState($getParameters)
 
-        # Call the overloaded method Get() to get the properties to return.
-        return ([ResourceBase] $this).Get($getCurrentStateResult)
-    }
-
-    <#
-        This overloaded method should be merged together with Get() above when
-        no resource uses it directly.
-    #>
-    [ResourceBase] Get([Microsoft.Management.Infrastructure.CimInstance] $CommandProperties)
-    {
         $dscResourceObject = [System.Activator]::CreateInstance($this.GetType())
 
         foreach ($propertyName in $this.PSObject.Properties.Name)
         {
-            if ($propertyName -in @($CommandProperties.PSObject.Properties.Name))
+            if ($propertyName -in @($getCurrentStateResult.PSObject.Properties.Name))
             {
-                $dscResourceObject.$propertyName = $CommandProperties.$propertyName
+                $dscResourceObject.$propertyName = $getCurrentStateResult.$propertyName
             }
         }
 
-        # Always set this as it won't be in the $CommandProperties
+        # Always set this as it won't be in the $getCurrentStateResult
         $dscResourceObject.DnsServer = $this.DnsServer
 
+        # Return properties.
         return $dscResourceObject
     }
 

--- a/source/Classes/003.DnsServerEDns.ps1
+++ b/source/Classes/003.DnsServerEDns.ps1
@@ -43,49 +43,29 @@ class DnsServerEDns : ResourceBase
 
     [DnsServerEDns] Get()
     {
-        Write-Verbose -Message ($this.localizedData.GetCurrentState -f $this.DnsServer)
-
-        $getDnsServerEDnsParameters = @{}
-
-        if ($this.DnsServer -ne 'localhost')
-        {
-            $getDnsServerEDnsParameters['ComputerName'] = $this.DnsServer
-        }
-
-        $getDnsServerEDnsResult = Get-DnsServerEDns @getDnsServerEDnsParameters
-
         # Call the base method to return the properties.
-        return ([ResourceBase] $this).Get($getDnsServerEDnsResult)
+        return ([ResourceBase] $this).Get()
+    }
+
+    # Base method Get() call this method to get the current state as a CimInstance.
+    [Microsoft.Management.Infrastructure.CimInstance] GetCurrentState([System.Collections.Hashtable] $properties)
+    {
+        return (Get-DnsServerEDns @properties)
     }
 
     [void] Set()
     {
-        $this.AssertProperties()
+        # Call the base method to enforce the properties.
+        ([ResourceBase] $this).Set()
+    }
 
-        Write-Verbose -Message ($this.localizedData.SetDesiredState -f $this.DnsServer)
-
-        # Call the base method to get enforced properties that are not in desired state.
-        $propertiesNotInDesiredState = $this.Compare()
-
-        if ($propertiesNotInDesiredState)
-        {
-            $setDnsServerEDnsParameters = $this.GetDesiredStateForSplatting($propertiesNotInDesiredState)
-
-            $setDnsServerEDnsParameters.Keys | ForEach-Object -Process {
-                Write-Verbose -Message ($this.localizedData.SetProperty -f $_, $setDnsServerEDnsParameters.$_)
-            }
-
-            if ($this.DnsServer -ne 'localhost')
-            {
-                $setDnsServerEDnsParameters['ComputerName'] = $this.DnsServer
-            }
-
-            Set-DnsServerEDns @setDnsServerEDnsParameters
-        }
-        else
-        {
-            Write-Verbose -Message $this.localizedData.NoPropertiesToSet
-        }
+    <#
+        Base method Set() call this method with the properties that should be
+        enforced and that are not in desired state.
+    #>
+    [void] Modify([System.Collections.Hashtable] $properties)
+    {
+        Set-DnsServerEDns @properties
     }
 
     [System.Boolean] Test()

--- a/source/Classes/003.DnsServerScavenging.ps1
+++ b/source/Classes/003.DnsServerScavenging.ps1
@@ -78,49 +78,29 @@ class DnsServerScavenging : ResourceBase
 
     [DnsServerScavenging] Get()
     {
-        Write-Verbose -Message ($this.localizedData.GetCurrentState -f $this.DnsServer)
-
-        $getDnsServerScavengingParameters = @{}
-
-        if ($this.DnsServer -ne 'localhost')
-        {
-            $getDnsServerScavengingParameters['ComputerName'] = $this.DnsServer
-        }
-
-        $getDnsServerScavengingResult = Get-DnsServerScavenging @getDnsServerScavengingParameters
-
         # Call the base method to return the properties.
-        return ([ResourceBase] $this).Get($getDnsServerScavengingResult)
+        return ([ResourceBase] $this).Get()
+    }
+
+    # Base method Get() call this method to get the current state as a CimInstance.
+    [Microsoft.Management.Infrastructure.CimInstance] GetCurrentState([System.Collections.Hashtable] $properties)
+    {
+        return (Get-DnsServerScavenging @properties)
     }
 
     [void] Set()
     {
-        $this.AssertProperties()
+        # Call the base method to enforce the properties.
+        ([ResourceBase] $this).Set()
+    }
 
-        Write-Verbose -Message ($this.localizedData.SetDesiredState -f $this.DnsServer)
-
-        # Call the base method to get enforced properties that are not in desired state.
-        $propertiesNotInDesiredState = $this.Compare()
-
-        if ($propertiesNotInDesiredState)
-        {
-            $setDnsServerScavengingParameters = $this.GetDesiredStateForSplatting($propertiesNotInDesiredState)
-
-            $setDnsServerScavengingParameters.Keys | ForEach-Object -Process {
-                Write-Verbose -Message ($this.localizedData.SetProperty -f $_, $setDnsServerScavengingParameters.$_)
-            }
-
-            if ($this.DnsServer -ne 'localhost')
-            {
-                $setDnsServerScavengingParameters['ComputerName'] = $this.DnsServer
-            }
-
-            Set-DnsServerScavenging @setDnsServerScavengingParameters
-        }
-        else
-        {
-            Write-Verbose -Message $this.localizedData.NoPropertiesToSet
-        }
+    <#
+        Base method Set() call this method with the properties that should be
+        enforced and that are not in desired state.
+    #>
+    [void] Modify([System.Collections.Hashtable] $properties)
+    {
+        Set-DnsServerScavenging @properties
     }
 
     [System.Boolean] Test()


### PR DESCRIPTION

### Pull Request (PR) description
- ResourceBase
  - For the method `Get()` the overload that took a `[Microsoft.Management.Infrastructure.CimInstance]`
    was removed as it is not the correct pattern going forward.
  - Added new method `Assert()` tha calls `Assert-Module` and `AssertProperties()`.
  - Moved the `Assert-Module` from the constructor to a new method `Assert()`
    that is called from `Get()`, `Test()`, and `Set()`. The method `Assert()`
    also calls the method `AssertProperties()`. The method `Assert()` is not
    meant to be overridden, but can if there is a reason not to run
    `Assert-Module` and or `AssertProperties()`.
- DnsServerCache
  - Moved to the same coding pattern as _DnsServerRecursion_.
- DnsServerEDns
  - Moved to the same coding pattern as _DnsServerRecursion_.
- DnsServerScavenging
  - Moved to the same coding pattern as _DnsServerRecursion_.

### This Pull Request (PR) fixes the following issues
None.

### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dnsserverdsc/247)
<!-- Reviewable:end -->
