### PR TITLE
DnsRecordPtr: IPv6 hot fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DnsServerScavenging
   - Moved to the same coding pattern as _DnsServerRecursion_.
 
+### Fixed
+
+- Logic bug in DnsRecordPtr.expandIPv6String($string) (#255)
+  - Supporting tests added
+
 ## [2.0.0] - 2021-03-26
 
 ### Deprecated

--- a/source/Classes/002.DnsRecordPtr.ps1
+++ b/source/Classes/002.DnsRecordPtr.ps1
@@ -145,7 +145,7 @@ class DnsRecordPtr : DnsRecordBase
         # Insert missing segments
         foreach ($segment in $segments)
         {
-            if ([string]::IsNullOrEmpty($segment))
+            if ([System.String]::IsNullOrEmpty($segment))
             {
                 for ($i = 0; $i -le $blankSegmentCount; $i++)
                 {

--- a/source/Classes/002.DnsRecordPtr.ps1
+++ b/source/Classes/002.DnsRecordPtr.ps1
@@ -6,13 +6,13 @@
         The DnsRecordPtr DSC resource manages PTR DNS records against a specific zone on a Domain Name System (DNS) server.
 
     .PARAMETER IpAddress
-       Specifies the IP address to which the record is associated (Can be either IPv4 or IPv6. (Key Parameter)
+        Specifies the IP address to which the record is associated (Can be either IPv4 or IPv6. (Key Parameter)
 
     .PARAMETER Name
-       Specifies the FQDN of the host when you add a PTR resource record. (Key Parameter)
+        Specifies the FQDN of the host when you add a PTR resource record. (Key Parameter)
 
     .NOTES
-       Reverse lookup zones do not support scopes, so there should be no DnsRecordPtrScoped subclass created.
+        Reverse lookup zones do not support scopes, so there should be no DnsRecordPtrScoped subclass created.
 #>
 
 [DscResource()]
@@ -139,14 +139,26 @@ class DnsRecordPtr : DnsRecordBase
         # Determine how many segments need to be added to reach the 8 required
         $blankSegmentCount = 8 - $segments.count
 
+        # Hold the expanded segments
+        $newSegments  = [System.Collections.ArrayList]::new()
+
         # Insert missing segments
-        for ($i = 0; $i -lt $blankSegmentCount; $i++)
+        foreach ($segment in $segments)
         {
-            $segments.Insert(1, '0000')
+            if ([string]::IsNullOrEmpty($segment))
+            {
+                for ($i = 0; $i -le $blankSegmentCount; $i++)
+                {
+                    $newSegments.Add('0000')
+                }
+            } else
+            {
+                $newSegments.Add($segment)
+            }
         }
 
         # Pad out all segments with leading zeros
-        $paddedSegments = $segments | ForEach-Object {
+        $paddedSegments = $newSegments | ForEach-Object {
             $_.PadLeft(4, '0')
         }
         return ($paddedSegments -join ':')

--- a/tests/Unit/Classes/DnsRecordPtr.v6.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordPtr.v6.tests.ps1
@@ -23,6 +23,55 @@ Get-Module -Name 'DnsServer' -All | Remove-Module -Force
 Import-Module -Name "$($PSScriptRoot)\..\Stubs\DnsServer.psm1"
 
 InModuleScope $ProjectName {
+
+    Describe "Testing the expandIPv6String method for completeness (See Issue #255)" -Tag 'expandIPv6String', 'DnsRecord', 'DnsRecordPtr' {
+        $testObj = [DnsRecordPtr]::new()
+
+        Context "Expands the following addresses correctly" {
+            @"
+3ea8:1140:571c:e8d8:2e83:cb3a:0000:9431
+c69e:276d:0e86:c274:c7f0:0000:8dc3:e662
+db8c:e4ec:32f7:41a2:0000:842e:d212:b4c2
+0a98:d329:7ed1:0000:a09e:8b35:19ea:5bd9
+53ed:054f:0000:8a4c:ed3b:218b:f2f2:a685
+e7b3:0000:4acf:f23c:d427:780a:f34c:833b
+164a:8626:55f8:c422:dd25:0000:0000:0a5b
+f0a0:fa5c:a0bf:5732:0000:0000:9b2e:2307
+afd4:640b:c7c3:0000:0000:c8b3:ae79:b2c4
+9b2e:7ede:0000:0000:6c70:0c44:26ff:39aa
+a5f2:0000:0000:ce7f:f152:e5bb:99de:7f7e
+5511:56ea:0b7c:fc9c:0000:0000:0000:664f
+6dc2:919a:ab83:0000:0000:0000:57e2:36c7
+13fa:2084:0000:0000:0000:8a14:bda1:377d
+122f:0000:0000:0000:f3e8:9a84:f1c5:674a
+ff02:6db3:354d:0000:0000:0000:0000:bc0c
+0018:0832:0000:0000:0000:0000:d4e7:71f4
+706e:0000:0000:0000:0000:98b5:ffe5:a652
+2950:e8ba:0000:0000:0000:0000:0000:f9ec
+e549:0000:0000:0000:0000:0000:9cca:40ad
+a788:0000:0000:0000:0000:0000:0000:c8db
+d730:a994:ff75:da7f:0000:8027:0000:0020
+2bb1:d12d:7fa2:5601:e9fa:22db:7412:51bd
+234d:0254:ac61:26df:56c5:25a1:eaf8:87cb
+0168:3293:f754:0000:bd31:f91a:0000:000e
+2b5b:b929:0243:529d:671b:597d:88be:28e9
+c74c:ca12:da15:bd3e:4037:ead2:6059:f14f
+4f85:bc16:e333:06b7:d948:60c1:5f61:66e3
+d861:9c60:c280:9f4e:705d:0b71:574d:7bdb
+493e:81ac:19f3:0dc5:042b:0c86:0a5b:b1cc
+7782:d54f:fc68:ceca:9d89:3879:a603:0e43
+7358:25cb:9973:d542:6658:9a9e:84d0:6b41
+"@ -split "`r*`n" | ForEach-Object {
+                $fullAddress = $_
+                $compactAddress = [System.Net.IpAddress]::Parse($fullAddress).IPAddressToString
+
+                It "$compactAddress -> $fullAddress" {
+                    $testObj.expandIPv6String($compactAddress) | Should -Be $fullAddress
+                }
+            }
+        }
+    }
+
     Describe "Testing DnsRecordPtr Get Method (IPv6 inputs)" -Tag 'Get', 'DnsRecord', 'DnsRecordPtr' {
         BeforeEach {
             $script:instanceDesiredState = [DnsRecordPtr] @{

--- a/tests/Unit/Classes/DnsRecordPtr.v6.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordPtr.v6.tests.ps1
@@ -28,7 +28,7 @@ InModuleScope $ProjectName {
         $testObj = [DnsRecordPtr]::new()
 
         Context "Expands the following addresses correctly" {
-            @"
+            $testCases = @"
 3ea8:1140:571c:e8d8:2e83:cb3a:0000:9431
 c69e:276d:0e86:c274:c7f0:0000:8dc3:e662
 db8c:e4ec:32f7:41a2:0000:842e:d212:b4c2
@@ -62,12 +62,18 @@ d861:9c60:c280:9f4e:705d:0b71:574d:7bdb
 7782:d54f:fc68:ceca:9d89:3879:a603:0e43
 7358:25cb:9973:d542:6658:9a9e:84d0:6b41
 "@ -split "`r*`n" | ForEach-Object {
-                $fullAddress = $_
-                $compactAddress = [System.Net.IpAddress]::Parse($fullAddress).IPAddressToString
-
-                It "$compactAddress -> $fullAddress" {
-                    $testObj.expandIPv6String($compactAddress) | Should -Be $fullAddress
+                @{
+                    FullAddress = $_
+                    CompactAddress = [System.Net.IpAddress]::Parse($_).IPAddressToString
                 }
+            }
+
+            It 'Expands <CompactAddress> -> <FullAddress>' -TestCases $testCases {
+                param (
+                    [System.String] $CompactAddress,
+                    [System.String] $FullAddress
+                )
+                $testObj.expandIPv6String($CompactAddress) | Should -Be $FullAddress
             }
         }
     }


### PR DESCRIPTION
### Pull Request (PR) description

Fixed logic bug in expanding IPv6 addresses used to detect the reverse lookup zone name.

### This Pull Request (PR) fixes the following issues

- Fixes #255

### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dnsserverdsc/256)
<!-- Reviewable:end -->
