### PR TITLE
Fix/274-stream-redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Pester tests
+  - Fixes a typo in stream suppression causing Error stream to be suppressed when
+    it was supposed not to be ([issue #274](https://github.com/dsccommunity/DnsServerDsc/issues/274)).
+
 ### Changed
 
 - DnsServerDsc
@@ -35,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `build.ps1`
   - Change from using `Test-DnsDscParameterState`
   to `Test-DscParameterState` (from _DscResource.Common_).
-  Fixes [[Issue #121](https://github.com/dsccommunity/DnsServerDsc/issues/121)].  
+  Fixes [[Issue #121](https://github.com/dsccommunity/DnsServerDsc/issues/121)].
   Affected resources:
     - `DSC_DnsServerDiagnostics`
     - `DSC_DnsServerRootHint`

--- a/tests/Integration/Classes/DnsRecordA.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordA.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.
@@ -186,7 +186,7 @@ Describe "$($script:dscResourceName)_Integration" {
             Test-DscConfiguration -Verbose | Should -Be 'True'
         }
     }
-    
+
     Context ('When using configuration <_>') -ForEach @(
         "$($script:dscResourceName)_DeleteRecord_Config"
     ) {

--- a/tests/Integration/Classes/DnsRecordAScoped.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordAScoped.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordAaaa.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordAaaa.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordAaaaScoped.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordAaaaScoped.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordCname.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordCname.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordCnameScoped.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordCnameScoped.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordMx.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordMx.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordMxScoped.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordMxScoped.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordNs.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordNs.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordNsScoped.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordNsScoped.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordPtr.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordPtr.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordPtr.v6.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordPtr.v6.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordSrv.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordSrv.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsRecordSrvScoped.integration.tests.ps1
+++ b/tests/Integration/Classes/DnsRecordSrvScoped.integration.tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsServerCache.Integration.Tests.ps1
+++ b/tests/Integration/Classes/DnsServerCache.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsServerDsSetting.Integration.Tests.ps1
+++ b/tests/Integration/Classes/DnsServerDsSetting.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsServerEDns.Integration.Tests.ps1
+++ b/tests/Integration/Classes/DnsServerEDns.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsServerRecursion.Integration.Tests.ps1
+++ b/tests/Integration/Classes/DnsServerRecursion.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/Classes/DnsServerScavenging.Integration.Tests.ps1
+++ b/tests/Integration/Classes/DnsServerScavenging.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerClientSubnet.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerClientSubnet.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerConditionalForwarder.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerConditionalForwarder.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerDiagnostics.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerDiagnostics.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerForwarder.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerForwarder.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerPrimaryZone.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerPrimaryZone.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerRootHint.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerRootHint.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerSetting.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerSetting.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerSettingLegacy.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerSettingLegacy.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerZoneAging.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerZoneAging.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Integration/DSC_DnsServerZoneScope.Integration.Tests.ps1
+++ b/tests/Integration/DSC_DnsServerZoneScope.Integration.Tests.ps1
@@ -11,7 +11,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordA.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordA.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordAScoped.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordAScoped.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordAaaa.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordAaaa.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordAaaaScoped.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordAaaaScoped.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordBase.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordBase.tests.ps1
@@ -21,7 +21,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordCname.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordCname.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordCnameScoped.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordCnameScoped.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordMx.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordMx.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordMxScoped.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordMxScoped.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.
@@ -506,7 +506,7 @@ Describe 'Testing DnsRecordMxScoped Set Method' -Tag 'Set', 'DnsRecord', 'DnsRec
                 Should -Invoke -CommandName Add-DnsServerResourceRecord -Exactly -Times 1 -Scope It
             }
         }
-        
+
         It 'Should call all verifiable mocks' {
             Should -InvokeVerifiable
         }

--- a/tests/Unit/Classes/DnsRecordNs.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordNs.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordNsScoped.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordNsScoped.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordPtr.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordPtr.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordPtr.v6.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordPtr.v6.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordSrv.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordSrv.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsRecordSrvScoped.tests.ps1
+++ b/tests/Unit/Classes/DnsRecordSrvScoped.tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsServerCache.Tests.ps1
+++ b/tests/Unit/Classes/DnsServerCache.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsServerDsSetting.Tests.ps1
+++ b/tests/Unit/Classes/DnsServerDsSetting.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsServerEDns.Tests.ps1
+++ b/tests/Unit/Classes/DnsServerEDns.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsServerRecursion.Tests.ps1
+++ b/tests/Unit/Classes/DnsServerRecursion.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Classes/DnsServerScavenging.Tests.ps1
+++ b/tests/Unit/Classes/DnsServerScavenging.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerADZone.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerADZone.Tests.ps1
@@ -18,7 +18,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerClientSubnet.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerClientSubnet.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerConditionalForwarder.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerConditionalForwarder.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.
@@ -526,7 +526,7 @@ Context 'DSC_DnsServerConditionalForwarder\Test-DscDnsServerConditionalForwarder
             $script:mockHelperParameters = $defaultParameters.Clone()
         }
     }
-    
+
     It 'When Ensure is present, and MasterServers is not set, throws an error' {
         InModuleScope -ScriptBlock {
             Set-StrictMode -Version 1.0

--- a/tests/Unit/DSC_DnsServerDiagnostics.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerDiagnostics.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerForwarder.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerForwarder.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerPrimaryZone.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerPrimaryZone.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.
@@ -440,7 +440,7 @@ Describe 'DSC_DnsServerPrimaryZone\Set-TargetResource' -Tag 'Set' {
 
                         Set-TargetResource @testParams
                     }
-                    
+
                     Should -Invoke -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $ZoneFile -eq 'nonexistent.com.dns' } -Scope It -Times 1 -Exactly
                     Should -Invoke -CommandName Get-DnsServerZone -Scope It -Times 1 -Exactly
                 }

--- a/tests/Unit/DSC_DnsServerRootHint.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerRootHint.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerSecondaryZone.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerSecondaryZone.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.
@@ -493,7 +493,7 @@ Describe 'DSC_DnsServerSecondaryZone\Test-ResourceProperties' -Tag 'Private' {
                         }
                         Test-ResourceProperties @params | Should -BeFalse
                     }
-                    
+
                     Should -Invoke -CommandName Get-DnsServerZone -Times 1 -Exactly
                 }
             }

--- a/tests/Unit/DSC_DnsServerSetting.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerSetting.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerSettingLegacy.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerSettingLegacy.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerZoneAging.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerZoneAging.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerZoneScope.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerZoneScope.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DSC_DnsServerZoneTransfer.Tests.ps1
+++ b/tests/Unit/DSC_DnsServerZoneTransfer.Tests.ps1
@@ -18,7 +18,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/DnsServerDsc.Common.Tests.ps1
+++ b/tests/Unit/DnsServerDsc.Common.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Private/Assert-TimeSpan.Tests.ps1
+++ b/tests/Unit/Private/Assert-TimeSpan.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.

--- a/tests/Unit/Private/ConvertTo-TimeSpan.Tests.ps1
+++ b/tests/Unit/Private/ConvertTo-TimeSpan.Tests.ps1
@@ -10,7 +10,7 @@ BeforeDiscovery {
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
-                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
             # If the dependencies has not been resolved, this will throw an error.


### PR DESCRIPTION
### Pull Request (PR) description

Fixes a typo in multiple Pester tests that caused Error stream to be suppressed while Warning stream was not, when the intention was to suppress everything but the Error stream.

With this PR the Warning stream is suppressed, and the Error stream is not.

### This Pull Request (PR) fixes the following issues

- Fixes #274

### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DnsServerDsc/275)
<!-- Reviewable:end -->
