### PR TITLE
fix: Issue 281

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use `New-ArgumentException` instead of `New-InvalidArgumentException`.
 - DSC_DnsServerClientSubnet
   - Fixed wrong SYNAPSIS.
+- DnsRecordA
+  - Fixed [[Issue #281](https://github.com/dsccommunity/DnsServerDsc/issues/281)].
 - Pester tests
   - Fixed issue with local testing on systems with non en-US Culture in DSC_DnsServerRootHint
     unit test. It fixes [[Issue #283](https://github.com/dsccommunity/DnsServerDsc/issues/283)].

--- a/source/Classes/030.DnsRecordA.ps1
+++ b/source/Classes/030.DnsRecordA.ps1
@@ -58,6 +58,13 @@ class DnsRecordA : DnsRecordBase
             $dnsParameters['ZoneScope'] = $this.ZoneScope
         }
 
+        # Using -Node parameter with Get-DnsServerResourceRecord if dealing with **same as parrent folder** record.
+        if ($this.Name -in '@', '.', $this.ZoneName)
+        {
+            $dnsParameters.Remove('Name')
+            $dnsParameters.Add('Node', $this.Name)
+        }
+
         $record = Get-DnsServerResourceRecord @dnsParameters -ErrorAction SilentlyContinue | Where-Object {
             $_.RecordData.IPv4Address -eq $this.IPv4Address
         }


### PR DESCRIPTION
### Pull Request (PR) description
Fix for issue with DnsRecordA resource when **same as parrent folder** ('@' or '.' or equal to ZoneName) could be created but could not be tested.

### This Pull Request (PR) fixes the following issues
- Fixes #281

### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
